### PR TITLE
Create kbd_backlight_toggle.sh

### DIFF
--- a/kbd_backlight_toggle.sh
+++ b/kbd_backlight_toggle.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Get the current brightness level of the device
+current_brightness=$(brightnessctl --device='asus::kbd_backlight' g)
+
+# Check if the brightness is off (0)
+if [ "$current_brightness" -eq 0 ]; then
+    # Turn the brightness to max (or your desired value for "on")
+    sudo brightnessctl --device='asus::kbd_backlight' s 3
+    echo "Keyboard backlight turned on (max brightness)."
+else
+    # Turn off the backlight if the backlight was aready on
+    sudo brightnessctl --device='asus::kbd_backlight' s 0
+    echo "Keyboard backlight turned off."
+fi


### PR DESCRIPTION
Designed for Asus device keyboards (tested on an Asus Zephyrus S running Ubuntu) where "**asus::kbd_backlight**" is the device intending to be controlled by the script. 

This script utilizes the **backlightctl** [utility](https://manpages.ubuntu.com/manpages/focal/en/man1/brightnessctl.1.html) and will require that installation before this will function. 

Additionally, the backlightctl utility will need to be added to the list of sudoers explicitly not requiring a password to be used as this utility will not function without the sudo privilege. 